### PR TITLE
Fix tintersects operator

### DIFF
--- a/pygeofilter/ast.py
+++ b/pygeofilter/ast.py
@@ -329,6 +329,7 @@ class TemporalComparisonOp(Enum):
     METBY = "METBY"
     TOVERLAPS = "TOVERLAPS"
     OVERLAPPEDBY = "OVERLAPPEDBY"
+    TINTERSECTS = "TINTERSECTS"
 
     BEFORE_OR_DURING = "BEFORE OR DURING"
     DURING_OR_AFTER = "DURING OR AFTER"
@@ -417,6 +418,11 @@ class TimeOverlaps(TemporalPredicate):
 @dataclass
 class TimeOverlappedBy(TemporalPredicate):
     op: ClassVar[TemporalComparisonOp] = TemporalComparisonOp.OVERLAPPEDBY
+
+
+@dataclass
+class TimeIntersects(TemporalPredicate):
+    op: ClassVar[TemporalComparisonOp] = TemporalComparisonOp.TINTERSECTS
 
 
 @dataclass

--- a/pygeofilter/cql2.py
+++ b/pygeofilter/cql2.py
@@ -48,7 +48,7 @@ TEMPORAL_PREDICATES_MAP: Dict[str, Type[ast.TemporalPredicate]] = {
     "t_ends": ast.TimeEnds,
     "t_endedby": ast.TimeEndedBy,
     "t_equals": ast.TimeEquals,
-    "t_intersects": ast.TimeOverlaps,
+    "t_intersects": ast.TimeIntersects,
 }
 
 

--- a/tests/parsers/cql2_json/test_parser.py
+++ b/tests/parsers/cql2_json/test_parser.py
@@ -256,6 +256,25 @@ def test_attribute_toverlaps_open_dt():
     )
 
 
+def test_attribute_tintersects_open_dt():
+    result = parse(
+        {
+            "op": "t_intersects",
+            "args": [
+                {"property": "attr"},
+                {"interval": ["..", "2000-01-01T00:00:03Z"]},
+            ],
+        }
+    )
+    assert result == ast.TimeIntersects(
+        ast.Attribute("attr"),
+        values.Interval(
+            None,
+            datetime(2000, 1, 1, 0, 0, 3, tzinfo=StaticTzInfo("Z", timedelta(0))),
+        ),
+    )
+
+
 def test_attribute_overlappedby_dt_open():
     result = parse(
         {

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -221,7 +221,7 @@ def test_attribute_tintersects_dt_dr():
     result = parse(
         "attr T_INTERSECTS INTERVAL('2000-01-01T00:00:03Z', '2000-01-01T00:00:04Z')"
     )
-    assert result == ast.TimeOverlaps(
+    assert result == ast.TimeIntersects(
         ast.Attribute("attr"),
         values.Interval(
             datetime(2000, 1, 1, 0, 0, 3, tzinfo=StaticTzInfo("Z", timedelta(0))),

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -208,7 +208,7 @@ def test_attribute_t_intersects():
     result = parse(
         "attr T_INTERSECTS INTERVAL('2000-01-01T00:00:00Z', '2000-01-01T00:00:01Z')"
     )
-    assert result == ast.TimeOverlaps(
+    assert result == ast.TimeIntersects(
         ast.Attribute("attr"),
         values.Interval(
             datetime(2000, 1, 1, 0, 0, 0, tzinfo=StaticTzInfo("Z", timedelta(0))),


### PR DESCRIPTION
Fix of strange behavior of parser changing "T_INTERSECTS" operator to "T_OVERLAPS" on CQL2 text requests.